### PR TITLE
add new parameter exportDetails (title, creator, album)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ optional arguments:
                         Export the playlist.
   -X, --exportAllPlaylists
                         Export all playlists.
+  -d  --exportDetails
+                        Export title, creator and album. Must be used with -x or -X.
+
   -f, --force           Force overwrite of export files.
   -i FILE, --importPlaylistFile FILE
                         Import the playlist file.


### PR DESCRIPTION
Hello,
thanks for your great work!
I have added a new parameter -d (--exportDetails) to export title, creator and album instead of location. I use this to export my Sonos playlists and import to Deezer, Spotify etc. with webpage http://soundiiz.com/#/converter. When adding location it does not work, so I removed it during export with detail parameter.
Additionally I have added UTF-8 file encoding.
Regards
Markus
